### PR TITLE
Properly install ansible

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,27 @@
+ansible/ansible-2.2.3.0.tar.gz:
+  size: 2512540
+  object_id: 3b5520e8-66ac-4037-7d9f-54cf01d3e98f
+  sha: 683f85ad478786677b95a0684538db458d0f7bfb
 ansible/ansible-v2.5.2.tar.gz:
   size: 10192927
   object_id: a449d0df-70e7-4843-4bb5-00396cb58357
   sha: 959523a9b1db5a34cb3c3f6d37137f5b8895a55d
+ansible/jinja-2.9.6.tar.gz:
+  size: 487185
+  object_id: 3b7d51bd-b42b-4251-42cb-0db829a0559f
+  sha: 22872d7b0d92e118bb11f25e59f413532a83f3ec
+ansible/paramiko-2.2.1.tar.gz:
+  size: 267771
+  object_id: 1720ac0b-043a-4c75-5f89-1ac6c9b79570
+  sha: 48b3d638e07aeb2d0b6e3ec6c3fbd38af3fd787f
+ansible/pycrypto-2.6.1.tar.gz:
+  size: 446240
+  object_id: acfa561d-c299-4bd2-434a-afa13d21d095
+  sha: aeda3ed41caf1766409d4efc689b9ca30ad6aeb2
+bzip2/bzip2-1.0.6.tar.gz:
+  size: 782025
+  object_id: e04b8b52-405f-4335-4e43-61fd36e66544
+  sha: 3f89f861209ce81a6bab1fd1998c0ef311712002
 cf-cli/cf-6.46.1.tgz:
   size: 5910456
   object_id: 4e1d0b05-5da2-41fd-4df8-f3c059c98240
@@ -38,10 +58,34 @@ jenkins/swarm-client-3.6.jar:
   size: 1620623
   object_id: 7960ab0b-6580-41ce-5139-43ebd3b390fa
   sha: e9ee5866393ccae0d4b5500ce5521e2850c98cf7
+libffi/libffi-3.2.1.tar.gz:
+  size: 940837
+  object_id: 6537c16f-5d43-42ea-4562-3fa4bbe7aa06
+  sha: 280c265b789e041c02e5c97815793dfc283fb1e6
+libyaml/yaml-0.1.7.tar.gz:
+  size: 527518
+  object_id: 7be15047-e2fb-4783-5a83-0c694ee29457
+  sha: 3590cbf092ef4c71bc0a9b404c00a626b1e04dee
+openssl/openssl-1.0.2l.tar.gz:
+  size: 5365054
+  object_id: 296d7490-d49c-48fe-512b-05f74fd08935
+  sha: b58d5d0e9cea20e571d903aafa853e2ccd914138
 oraclejava/jdk-8u161-linux-x64.tar.gz:
   size: 189756259
   object_id: eb100739-7d1c-48ff-5687-ee2ad4f0209f
   sha: 9662b358ec90ecdc2c06acc2e326fbf25eaf567d
+pip/pip-9.0.1.tar.gz:
+  size: 6109437
+  object_id: e00b15d5-f060-4006-538a-70a55853534a
+  sha: 39b5840f6a9e6888d56a78beb447a064aeaf1592
+python/Python-2.7.13.tar.xz:
+  size: 12495628
+  object_id: b35020c1-6009-43aa-42b1-e813813e7284
+  sha: 18a8f30a0356c751b8d0ea6f76e764cab13ee046
+setuptools/setuptools-36.0.1.tar.gz:
+  size: 659748
+  object_id: 56f73541-1cf3-4170-7d26-63174bc92e0c
+  sha: c8b9d7019eafc6e7b296052b6ee1ca6b0c14d764
 swarm-client/swarm-client-2.2-jar-with-dependencies.jar:
   size: 1385476
   object_id: 0955da33-cdff-4169-7914-fa46bfb086a9
@@ -50,3 +94,7 @@ terraform/terraform_0.11.7_linux_amd64.zip:
   size: 16490308
   object_id: cff2eaff-828c-48ae-675d-103506b0ac97
   sha: 5b2e6b61692c538afd9103741cd5092ef50d6723
+zlib/zlib-1.2.11.tar.gz:
+  size: 607698
+  object_id: 6c14e420-bb44-45d0-4d83-8ee60eae9b34
+  sha: e6d119755acdf9104d7ba236b1242696940ed6dd

--- a/packages/ansible/packaging
+++ b/packages/ansible/packaging
@@ -1,5 +1,107 @@
-set -e
+#!/usr/bin/env bash
 
-ANSIBLE_VERSION=v2.5.2
+# abort script on any command that exits with a non zero value
+set -e -x
 
-tar xvfz ansible/ansible-${ANSIBLE_VERSION}.tar.gz --strip-components=1 -C ${BOSH_INSTALL_TARGET}
+# Grab the latest versions that are in the directory
+ANSIBLE_VERSION=$(ls -r ansible/ansible-*.tar.gz | sed 's/.*\/ansible-\(.*\)\.tar\.gz$/\1/' | head -1)
+PYCRYPTO_VERSION=$(ls -r ansible/pycrypto-*.tar.gz | sed 's/.*\/pycrypto-\(.*\)\.tar\.gz$/\1/' | head -1)
+JINJA_VERSION=$(ls -r ansible/jinja-*.tar.gz | sed 's/.*\/jinja-\(.*\)\.tar\.gz$/\1/' | head -1)
+PARAMIKO_VERSION=$(ls -r ansible/paramiko-*.tar.gz | sed 's/.*\/paramiko-\(.*\)\.tar\.gz$/\1/' | head -1)
+LIBFFI_VERSION="3.2.1"
+BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
+JOB_NAME="ansible"
+
+# Integrate contents of all packages to this folder, so only this package needs
+# to be included in the job
+for pkg in $(ls --ignore=ansible ${BOSH_PACKAGES_DIR}); do
+    echo "Integrating ${BOSH_PACKAGES_DIR}/${pkg}/* in ${BOSH_INSTALL_TARGET}"
+    cp -av ${BOSH_PACKAGES_DIR}/${pkg}/* ${BOSH_INSTALL_TARGET}
+done
+
+
+echo "Extracting pycrypto ${PYCRYPTO_VERSION} ..."
+tar xvf "ansible/pycrypto-${PYCRYPTO_VERSION}.tar.gz"
+
+echo "Extracting jinja ${JINJA_VERSION} ..."
+tar xvf "ansible/jinja-${JINJA_VERSION}.tar.gz"
+
+echo "Extracting paramiko ${PARAMIKO_VERSION} ..."
+tar xvf "ansible/paramiko-${PARAMIKO_VERSION}.tar.gz"
+
+echo "Extracting ansible ${ANSIBLE_VERSION} ..."
+tar xvf "ansible/ansible-${ANSIBLE_VERSION}.tar.gz"
+
+echo "Creating python site packages folder ..."
+mkdir -p ${BOSH_INSTALL_TARGET}/lib/python2.7/site-packages
+
+
+# In all these paths the priority is set to the current folder, why?
+# * to make it usable when contents from other packages are copied (integrated) on this package
+# * to reuse this package in other releases (as standalone package)
+# Python setuptools/pip install the contents and create the shebang based
+# on the python binary location, so sometimes the shebang does not point
+# a proper path in case the contents were copied from other package.
+# The option in setup.py "build --executable='python'" defines the shebang,
+# but depending on the setuptools, is not always working.
+
+echo "Setting the PYTHONPATH with setuptools and ansible site packages ..."
+PYTHONPATH="${BOSH_INSTALL_TARGET}/lib/python2.7/site-packages:${PYTHONPATH}"
+for package_python_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/lib/python*/site-packages 2>/dev/null); do
+    PYTHONPATH="${package_python_dir}:${PYTHONPATH}"
+done
+for package_python_dir in $(ls -d ${BOSH_INSTALL_TARGET}/lib/python*/site-packages 2>/dev/null); do
+    PYTHONPATH="${package_python_dir}:${PYTHONPATH}"
+done
+export PYTHONPATH
+
+echo "Setting libs path ..."
+for package_lib_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/lib 2>/dev/null); do
+    LIBRARY_PATH="${package_lib_dir}:${LIBRARY_PATH}"
+done
+export LIBRARY_PATH="${BOSH_INSTALL_TARGET}/lib:${LIBRARY_PATH}"
+export LD_LIBRARY_PATH="${LIBRARY_PATH}"
+
+echo "Setting path ..."
+for package_bin_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/bin 2>/dev/null); do
+    PATH="${package_bin_dir}:${PATH}"
+done
+export PATH="${BOSH_INSTALL_TARGET}/bin:${PATH}"
+
+echo "Setting setuptools build sources ..."
+CPATH="${BOSH_PACKAGES_DIR}/libffi/lib/libffi-${LIBFFI_VERSION}/include"
+for package_cpath_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/include 2>/dev/null); do
+    CPATH="${package_cpath_dir}:${CPATH}"
+done
+export CPATH="${BOSH_INSTALL_TARGET}/include:${CPATH}"
+
+echo "Installing pycrypto ..."
+pushd "pycrypto-${PYCRYPTO_VERSION}"
+  # python setup.py build --executable='python' install --prefix=${BOSH_INSTALL_TARGET}
+  python setup.py install --prefix=${BOSH_INSTALL_TARGET}
+popd
+
+echo "Installing jinja ..."
+pushd "jinja-${JINJA_VERSION}"
+  # python setup.py build --executable='python' install --prefix=${BOSH_INSTALL_TARGET}
+  python setup.py install --prefix=${BOSH_INSTALL_TARGET}
+popd
+
+echo "Installing paramiko ..."
+pushd "paramiko-${PARAMIKO_VERSION}"
+  # python setup.py build --executable='python' install --prefix=${BOSH_INSTALL_TARGET}
+  python setup.py install --prefix=${BOSH_INSTALL_TARGET}
+popd
+
+echo "Installing ansible ..."
+pushd "ansible-${ANSIBLE_VERSION}"
+  # python setup.py build --executable='python' install --prefix=${BOSH_INSTALL_TARGET}
+  python setup.py install --prefix=${BOSH_INSTALL_TARGET}
+popd
+
+# remove full path in *.pth
+for pth in $(ls ${BOSH_INSTALL_TARGET}/lib/python*/site-packages/*.pth 2>/dev/null); do
+  echo "Changing full path in: $pth"
+  sed -i -e 's:^/var/vcap/data/packages/.*/site-packages:.:' $pth
+done
+

--- a/packages/ansible/spec
+++ b/packages/ansible/spec
@@ -1,7 +1,18 @@
 ---
 name: ansible
 
-dependencies: []
+dependencies:
+- libyaml
+- openssl
+- zlib
+- bzip2
+- libffi
+- python27
+- setuptools
+- pip
 
 files:
-- ansible/ansible-v2.5.2.tar.gz
+- ansible/ansible-2.2.3.0.tar.gz        # http://releases.ansible.com/ansible/ansible-2.2.3.0.tar.gz
+- ansible/pycrypto-2.6.1.tar.gz         # https://pypi.python.org/packages/60/db/645aa9af249f059cc3a368b118de33889219e0362141e75d4eaf6f80f163/pycrypto-2.6.1.tar.gz
+- ansible/jinja-2.9.6.tar.gz            # https://github.com/pallets/jinja/archive/2.9.6.tar.gz
+- ansible/paramiko-2.2.1.tar.gz         # https://github.com/paramiko/paramiko/archive/2.2.1.tar.gz

--- a/packages/bzip2/packaging
+++ b/packages/bzip2/packaging
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# abort script on any command that exits with a non zero value
+set -e -x
+
+# Grab the latest versions that are in the directory
+BZIP2_VERSION=$(ls -r bzip2/bzip2-*.tar.gz | sed 's/.*\/bzip2-\(.*\)\.tar\.gz$/\1/' | head -1)
+BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
+
+echo "Extracting bzip2 ${BZIP2_VERSION} ... "
+tar xzvf "bzip2/bzip2-${BZIP2_VERSION}.tar.gz"
+
+echo "Building bzip2 ... "
+pushd "bzip2-${BZIP2_VERSION}"
+  export CFLAGS="$CFLAGS -fPIC"
+  make -f Makefile-libbz2_so
+  make
+  make install PREFIX=${BOSH_INSTALL_TARGET}
+  cp -a *.so* ${BOSH_INSTALL_TARGET}/lib
+popd

--- a/packages/bzip2/spec
+++ b/packages/bzip2/spec
@@ -1,0 +1,7 @@
+---
+name: bzip2
+
+dependencies: []
+
+files:
+- bzip2/bzip2-1.0.6.tar.gz      # http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz

--- a/packages/libffi/packaging
+++ b/packages/libffi/packaging
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# abort script on any command that exits with a non zero value
+set -e -x
+
+# Grab the latest versions that are in the directory
+LIBFFI_VERSION=$(ls -r libffi/libffi-*.tar.gz | sed 's/.*\/libffi-\(.*\)\.tar\.gz$/\1/' | head -1)
+BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
+
+echo "Extracting libffi ${LIBFFI_VERSION} ... "
+tar xzvf "libffi/libffi-${LIBFFI_VERSION}.tar.gz"
+
+echo "Building libffi ... "
+pushd "libffi-${LIBFFI_VERSION}"
+  ./configure --prefix=${BOSH_INSTALL_TARGET}
+  make
+  make install
+popd

--- a/packages/libffi/spec
+++ b/packages/libffi/spec
@@ -1,0 +1,7 @@
+---
+name: libffi
+
+dependencies: []
+
+files:
+- libffi/libffi-3.2.1.tar.gz    # ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz

--- a/packages/libyaml/packaging
+++ b/packages/libyaml/packaging
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# abort script on any command that exits with a non zero value
+set -e -x
+
+# Grab the latest versions that are in the directory
+LIBYAML_VERSION=$(ls -r libyaml/yaml-*.tar.gz | sed 's/.*\/yaml-\(.*\)\.tar\.gz$/\1/' | head -1)
+BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
+
+echo "Extracting libyaml ${LIBYAML_VERSION} ... "
+tar xzvf "libyaml/yaml-${LIBYAML_VERSION}.tar.gz"
+
+echo "Building libyaml ... "
+pushd "yaml-${LIBYAML_VERSION}"
+  ./configure --prefix=${BOSH_INSTALL_TARGET}
+  make
+  make install
+popd

--- a/packages/libyaml/spec
+++ b/packages/libyaml/spec
@@ -1,0 +1,7 @@
+---
+name: libyaml
+
+dependencies: []
+
+files:
+- libyaml/yaml-0.1.7.tar.gz     # http://pyyaml.org/download/libyaml/yaml-0.1.7.tar.gz

--- a/packages/openssl/packaging
+++ b/packages/openssl/packaging
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# abort script on any command that exits with a non zero value
+set -e -x
+
+# Grab the latest versions that are in the directory
+OPENSSL_VERSION=$(ls -r openssl/openssl-*.tar.gz | sed 's/.*\/openssl-\(.*\)\.tar\.gz$/\1/' | head -1)
+BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
+
+echo "Extracting openssl ${OPENSSL_VERSION} ... "
+tar xvf "openssl/openssl-${OPENSSL_VERSION}.tar.gz"
+
+echo "Building openssl ... "
+export CFLAGS="-fPIC ${CFLAGS}"
+for package_include_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/include 2>/dev/null); do
+    CPPFLAGS="-I${package_include_dir} ${CPPFLAGS}"
+done
+for package_lib_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/lib 2>/dev/null); do
+    LDFLAGS="-L${package_lib_dir} ${LDFLAGS}"
+    LIBRARY_PATH="${package_lib_dir}:${LIBRARY_PATH}"
+done
+export CPPFLAGS
+export LDFLAGS
+export LIBRARY_PATH
+
+echo "Building and installing openssl ... "
+pushd "openssl-${OPENSSL_VERSION}"
+  ./config --prefix=${BOSH_INSTALL_TARGET} --openssldir=${BOSH_INSTALL_TARGET}/openssl shared zlib
+  make
+  make install
+popd

--- a/packages/openssl/prepare
+++ b/packages/openssl/prepare
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+PACKAGE="openssl"
+VERSION="1.0.2l"
+FILE="openssl-${VERSION}.tar.gz"
+URL="https://www.openssl.org/source/openssl-${VERSION}.tar.gz"
+
+if [ ! -s "${PACKAGE}/${FILE}" ]; then
+  echo "  Downloading ${URL} ..."
+  mkdir -p ${PACKAGE}
+  curl -L -s "${URL}" -o "${PACKAGE}/${FILE}"
+fi

--- a/packages/openssl/spec
+++ b/packages/openssl/spec
@@ -1,0 +1,8 @@
+---
+name: openssl
+
+dependencies:
+- zlib
+
+files:
+- openssl/openssl-1.0.2l.tar.gz     # http://openssl.org/source/openssl-1.0.2l.tar.gz

--- a/packages/packaging
+++ b/packages/packaging
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# abort script on any command that exits with a non zero value
+set -e -x
+
+# Grab the latest versions that are in the directory
+LIBYAML_VERSION=$(ls -r libyaml/yaml-*.tar.gz | sed 's/.*\/yaml-\(.*\)\.tar\.gz$/\1/' | head -1)
+BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
+
+echo "Extracting libyaml ${LIBYAML_VERSION} ... "
+tar xzvf "libyaml/yaml-${LIBYAML_VERSION}.tar.gz"
+
+echo "Building libyaml ... "
+pushd "yaml-${LIBYAML_VERSION}"
+  ./configure --prefix=${BOSH_INSTALL_TARGET}
+  make
+  make install
+popd

--- a/packages/pip/packaging
+++ b/packages/pip/packaging
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# abort script on any command that exits with a non zero value
+set -e -x
+
+# Grab the latest versions that are in the directory
+PIP_VERSION=$(ls -r -v pip/pip-*.tar.gz | sed 's/.*\/pip-\(.*\)\.tar\.gz$/\1/' | head -1)
+BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
+
+echo "Extracting pip ${PIP_VERSION} ..."
+tar xvf "pip/pip-${PIP_VERSION}.tar.gz"
+
+echo "Creating the site packages ... "
+mkdir -p ${BOSH_INSTALL_TARGET}/lib/python2.7/site-packages
+
+echo "Setting the PYTHONPATH with setuptools site packages..."
+PYTHONPATH="${BOSH_INSTALL_TARGET}/lib/python2.7/site-packages:${PYTHONPATH}"
+for package_python_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/lib/python*/site-packages 2>/dev/null); do
+    PYTHONPATH="${package_python_dir}:${PYTHONPATH}"
+done
+export PYTHONPATH
+
+for package_lib_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/lib 2>/dev/null); do
+    LIBRARY_PATH="${package_lib_dir}:${LIBRARY_PATH}"
+done
+export LIBRARY_PATH
+export LD_LIBRARY_PATH="${LIBRARY_PATH}"
+
+echo "Installing pip ..."
+for package_bin_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/bin 2>/dev/null); do
+    PATH="${package_bin_dir}:${PATH}"
+done
+export PATH
+
+pushd "pip-${PIP_VERSION}"
+  python setup.py build --executable='/usr/bin/env python' install --prefix=${BOSH_INSTALL_TARGET}
+popd
+
+# remove shebang pointing to packages dir
+for pyf in ${BOSH_INSTALL_TARGET}/bin/*; do
+  if file -b $pyf | grep -iq "python.* script"; then
+    echo "Changing shebang: $pyf"
+    sed -i -e '1s:^#!/var/vcap/packages/python[0-9a-zA-Z_\.-]*/bin/python[0-9a-zA-Z_\.-]*:#!/usr/bin/env python:' $pyf
+  fi
+done
+
+# remove full path in *.pth
+for pth in $(ls ${BOSH_INSTALL_TARGET}/lib/python*/site-packages/*.pth 2>/dev/null); do
+  echo "Changing full path in: $pth"
+  sed -i -e 's:^/var/vcap/data/packages/.*/site-packages:.:' $pth
+done
+

--- a/packages/pip/spec
+++ b/packages/pip/spec
@@ -1,0 +1,13 @@
+---
+name: pip
+
+dependencies:
+- bzip2
+- zlib
+- openssl
+- libyaml
+- python27
+- setuptools
+
+files:
+- pip/pip-9.0.1.tar.gz      # https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz

--- a/packages/python27/packaging
+++ b/packages/python27/packaging
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# abort script on any command that exits with a non zero value
+set -e -x
+
+# Grab the latest versions that are in the directory
+PYTHON_VERSION=$(ls -r python/Python-*.tar.xz | sed 's/.*\/Python-\(.*\)\.tar\.xz$/\1/' | head -1)
+BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
+
+echo "Extracting python ${PYTHON_VERSION} ... "
+tar xvf python/Python-${PYTHON_VERSION}.tar.xz
+
+echo "Defining libraries path ..."
+export CFLAGS="-fPIC ${CFLAGS}"
+for package_include_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/include 2>/dev/null); do
+    CPPFLAGS="-I${package_include_dir} ${CPPFLAGS}"
+done
+for package_lib_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/lib 2>/dev/null); do
+    LDFLAGS="-L${package_lib_dir} ${LDFLAGS}"
+    LIBRARY_PATH="${package_lib_dir}:${LIBRARY_PATH}"
+done
+export CPPFLAGS
+export LDFLAGS
+export LIBRARY_PATH
+export LD_LIBRARY_PATH="${LIBRARY_PATH}"
+
+echo "Building and installing Python ... "
+pushd Python-${PYTHON_VERSION}
+  ./configure --enable-optimizations --prefix=${BOSH_INSTALL_TARGET}
+  make -j 4
+  make install
+popd
+
+# remove shebang pointing to packages dir
+for pyf in ${BOSH_INSTALL_TARGET}/bin/*; do
+  if file -b $pyf | grep -iq "python.* script"; then
+    echo "Changing shebang: $pyf"
+    sed -i -e '1s:^#!/var/vcap/packages/python[0-9a-zA-Z_\.-]*/bin/python[0-9a-zA-Z_\.-]*:#!/usr/bin/env python:' $pyf
+  fi
+done
+
+# remove full path in setuptools.pth
+for pth in $(ls ${BOSH_INSTALL_TARGET}/lib/python*/site-packages/*.pth 2>/dev/null); do
+  echo "Changing full path in: $pth"
+  sed -i -e 's:^/var/vcap/data/packages/.*/site-packages:.:' $pth
+done
+

--- a/packages/python27/spec
+++ b/packages/python27/spec
@@ -1,0 +1,10 @@
+---
+name: python27
+
+dependencies:
+- zlib
+- bzip2
+- openssl
+
+files:
+- python/Python-2.7.13.tar.xz   # https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tar.xz

--- a/packages/setuptools/packaging
+++ b/packages/setuptools/packaging
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# abort script on any command that exits with a non zero value
+set -e -x
+
+# Grab the latest versions that are in the directory
+SETUPTOOLS_VERSION=$(ls -r -v setuptools/setuptools-*.tar.gz | sed 's/.*\/setuptools-\(.*\)\.tar\.gz$/\1/' | head -1)
+BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
+
+echo "Extracting setuptools ${SETUPTOOLS_VERSION} ... "
+tar xvf "setuptools/setuptools-${SETUPTOOLS_VERSION}.tar.gz"
+
+echo "Creating the setuptools site packages ... "
+mkdir -p ${BOSH_INSTALL_TARGET}/lib/python2.7/site-packages
+
+echo "Setting the PYTHONPATH with setuptools site packages..."
+export PYTHONPATH="${BOSH_INSTALL_TARGET}/lib/python2.7/site-packages:${PYTHONPATH}"
+
+echo "Installing setuptools ..."
+for package_lib_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/lib 2>/dev/null); do
+    LIBRARY_PATH="${package_lib_dir}:${LIBRARY_PATH}"
+done
+export LIBRARY_PATH
+export LD_LIBRARY_PATH="${LIBRARY_PATH}"
+
+for package_bin_dir in $(ls -d ${BOSH_PACKAGES_DIR}/*/bin 2>/dev/null); do
+    PATH="${package_bin_dir}:${PATH}"
+done
+export PATH
+
+pushd "setuptools-${SETUPTOOLS_VERSION}"
+  python bootstrap.py
+  python setup.py build --executable='/usr/bin/env python' install --prefix=${BOSH_INSTALL_TARGET}
+popd
+
+# remove shebang pointing to packages dir
+for pyf in ${BOSH_INSTALL_TARGET}/bin/*; do
+  if file -b $pyf | grep -iq "python.* script"; then
+    echo "Changing shebang: $pyf"
+    sed -i -e '1s:^#!/var/vcap/packages/python[0-9a-zA-Z_\.-]*/bin/python[0-9a-zA-Z_\.-]*:#!/usr/bin/env python:' $pyf
+  fi
+done
+
+# remove full path in setuptools.pth
+for pth in $(ls ${BOSH_INSTALL_TARGET}/lib/python*/site-packages/*.pth 2>/dev/null); do
+  echo "Changing full path in: $pth"
+  sed -i -e 's:^/var/vcap/data/packages/.*/site-packages:.:' $pth
+done
+

--- a/packages/setuptools/spec
+++ b/packages/setuptools/spec
@@ -1,0 +1,11 @@
+---
+name: setuptools
+
+dependencies:
+- zlib
+- bzip2
+- openssl
+- python27
+
+files:
+- setuptools/setuptools-36.0.1.tar.gz   # https://github.com/pypa/setuptools/archive/v36.2.7.tar.gz

--- a/packages/spec
+++ b/packages/spec
@@ -1,0 +1,7 @@
+---
+name: libyaml
+
+dependencies: []
+
+files:
+- libyaml/yaml-0.1.7.tar.gz     # http://pyyaml.org/download/libyaml/yaml-0.1.7.tar.gz

--- a/packages/zlib/packaging
+++ b/packages/zlib/packaging
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# abort script on any command that exits with a non zero value
+set -e -x
+
+# Grab the latest versions that are in the directory
+ZLIB_VERSION=$(ls -r zlib/zlib-*.tar.gz | sed 's/.*\/zlib-\(.*\)\.tar\.gz$/\1/' | head -1)
+BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
+
+echo "Extracting zlib ${ZLIB_VERSION} ... "
+tar xzvf "zlib/zlib-${ZLIB_VERSION}.tar.gz"
+
+echo "Building zlib ... "
+pushd "zlib-${ZLIB_VERSION}"
+  ./configure --prefix=${BOSH_INSTALL_TARGET}
+  make
+  make install
+popd

--- a/packages/zlib/spec
+++ b/packages/zlib/spec
@@ -1,0 +1,7 @@
+---
+name: zlib
+
+dependencies: []
+
+files:
+- zlib/zlib-1.2.11.tar.gz    # http://zlib.net/zlib-1.2.11.tar.gz


### PR DESCRIPTION
Based off https://github.com/SpringerPE/ansible-boshrelease

Jenkins slave errored when an ansible playbook was run/executed. It turns out just unzipping the ansible tar.gz file isn't enough.

Deploying this in BOSH Lite, the ansible-playbook command returns successfully:

jenkins-slave/05bbea02-2703-4a6b-8972-ffbd99568570:~$ /var/vcap/packages/ansible/bin/ansible-playbook --version
ansible-playbook 2.2.3.0
  config file =
  configured module search path = Default w/o overrides

Admittedly it's an older version of ansible, but that can be upgraded later.