### PR TITLE
Change permissions of 'id_rsa' on jenkins slave to 0600

### DIFF
--- a/jobs/jenkins-slave/templates/bin/pre-start
+++ b/jobs/jenkins-slave/templates/bin/pre-start
@@ -16,6 +16,7 @@ chown vcap:vcap /home/vcap/.gitconfig
 mkdir -p /home/vcap/.ssh
 if [[ -d /home/vcap/.ssh ]]; then
   mv /var/vcap/jobs/jenkins-slave/config/id_rsa /home/vcap/.ssh/
+  chmod 0600 /home/vcap/.ssh/id_rsa
   chown -R vcap:vcap /home/vcap/.ssh
 fi
 


### PR DESCRIPTION
Resolves '[ERROR] Permissions 0640 for '/home/vcap/.ssh/id_rsa' are too open.' error