### PR TITLE
Add ability to disable plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ bosh -e MY_ENV \
 bosh -e MY_ENV \
   upload-release
 ```
+
+## 3. Configuration
+### Disabling installed plugins
+Installed plugins may be disabled at deployment time by providing a list of plugins to be disabled in an operations file.
+e.g. disable-plugins.yml
+```
+---
+- type: replace
+  path: /instance_groups/name=jenkins-master/jobs/name=jenkins-master/properties?/jenkins/disabled_plugins
+  value: |
+    gatling
+    scoverage
+    whitesource
+```

--- a/jobs/jenkins-master/spec
+++ b/jobs/jenkins-master/spec
@@ -185,3 +185,7 @@ properties:
   toggle.jenkins.drain:
     description: "Toggle drain feature"
     default: false
+  jenkins.disabled_plugins:
+    description: "List of installed plugins to be disabled"
+    default: |
+      example

--- a/jobs/jenkins-master/templates/bin/pre-start.erb
+++ b/jobs/jenkins-master/templates/bin/pre-start.erb
@@ -45,6 +45,15 @@ touch /var/vcap/store/jenkins-master/plugins/cvs.jpi.disabled
 touch /var/vcap/store/jenkins-master/plugins/ant.jpi.disabled
 touch /var/vcap/store/jenkins-master/plugins/translation.jpi.disabled
 
+OLDIFS=$IFS
+IFS=$'\n'
+plugins=(<%= p('jenkins.disabled_plugins') %>)
+IFS=$OLDIFS
+for (( i=0; i<${#plugins[@]}; i++ )); do
+    echo "Disabling ${plugins[$i]} plugin"
+    touch /var/vcap/store/jenkins-master/plugins/${plugins[$i]}.jpi.disabled
+done
+
 if [[ ! -d /var/vcap/store/jenkins-master/userContent ]]; then
     echo "Copying UserContent..."
     cp /var/vcap/jobs/jenkins-master/config/*.png /var/vcap/store/jenkins-master/userContent


### PR DESCRIPTION
Allows Jenkins plugins to be disabled during deployment using an
operations file to provide a list of plugins to disable.