### PR TITLE
trigger on cf-deployment-concourse-tasks

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -163,6 +163,7 @@ jobs:
     - get: bbl-state
     - get: concourse-tasks
     - get: cf-deployment-concourse-tasks
+      trigger: true
     - get: jenkins-boshrelease
       passed:
       - create-dev-release


### PR DESCRIPTION
this will prove new versions of bbl as they come out rather than when we want to create a jenkins release