### PR TITLE
Drain timeout reduced to 5 minutes

### DIFF
--- a/jobs/jenkins-master/templates/bin/drain.erb
+++ b/jobs/jenkins-master/templates/bin/drain.erb
@@ -15,7 +15,7 @@ if [ ${JENKINS_USE_GITHUB_AUTH} = "false" ]; then
 fi
 
 SLEEP_INTERVAL_IN_SECONDS=5
-TIMEOUT_IN_SECONDS=600
+TIMEOUT_IN_SECONDS=300
 CRUMB_PATH='/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'
 BUILDS_PATH="/api/xml?&tree=jobs[builds[*]]&xpath=/hudson/job/build[building=%22true%22]&wrapper=builds"
 


### PR DESCRIPTION
To reduce the change of BOSH deploy timeouts.